### PR TITLE
Add bidirectional Karabiner sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ bb setup tmux
 bb setup nvim
 bb setup hammerspoon
 bb setup karabiner
+bb sync karabiner pull
 bb setup ghostty
 ```
 
@@ -93,7 +94,7 @@ This is ideal if you want to add pieces over time.
 | Tmux | `bb setup tmux` | prefix Ctrl+b and sesh integration | `docs/modules/tmux.md` |
 | Neovim | `bb setup nvim` | bleeding-edge vim.pack config for Neovim 0.12+ | `docs/modules/nvim.md` |
 | Hammerspoon | `bb setup hammerspoon` | Hyper app launcher + Ghostty 4-pane hotkey | `docs/modules/hammerspoon.md` |
-| Karabiner | `bb setup karabiner` | macOS only, jk to tmux prefix | `docs/modules/karabiner.md` |
+| Karabiner | `bb setup karabiner` | macOS only, jk to tmux prefix, `bb sync karabiner pull` imports live config | `docs/modules/karabiner.md` |
 | Ghostty | `bb setup ghostty` | terminal config | `docs/modules/ghostty.md` |
 | Mackup | `bb setup mackup` | app settings backup | `docs/modules/mackup.md` |
 | AI configs | `bb setup` | auto-copied from templates | `docs/modules/ai.md` |

--- a/docs/modules/karabiner.md
+++ b/docs/modules/karabiner.md
@@ -18,7 +18,15 @@ This stows the config and restarts Karabiner Elements.
 Manual sync and restart:
 
 ```bash
-./scripts/sync-karabiner.sh
+./scripts/sync-karabiner.sh push
+```
+
+Pull the current machine config back into dotfiles:
+
+```bash
+bb sync karabiner pull
+# or
+./scripts/sync-karabiner.sh pull
 ```
 
 ## Key mappings

--- a/scripts/sync-karabiner.sh
+++ b/scripts/sync-karabiner.sh
@@ -1,35 +1,103 @@
 #!/bin/bash
-# Sync karabiner config from dotfiles and reload Karabiner Elements
+# Sync karabiner config between dotfiles and the live machine config.
 
-set -e
+set -euo pipefail
 
+MODE="${1:-push}"
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 KARABINER_SOURCE="$DOTFILES_DIR/stow-packages/karabiner/.config/karabiner/karabiner.json"
 KARABINER_DEST="$HOME/.config/karabiner/karabiner.json"
 
-# Ensure destination directory exists
-mkdir -p "$(dirname "$KARABINER_DEST")"
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/sync-karabiner.sh [push|pull]
 
-# Copy the config unless destination is a symlink to the source
-if [[ -L "$KARABINER_DEST" ]]; then
-    link_target="$(readlink "$KARABINER_DEST")"
-    if [[ "$link_target" == "$KARABINER_SOURCE" ]]; then
-        echo "✓ karabiner.json already linked"
-    else
-        echo "Warning: karabiner.json is a symlink to $link_target (skipping copy)"
-    fi
-else
-    cp "$KARABINER_SOURCE" "$KARABINER_DEST"
-    echo "✓ Synced karabiner.json"
-fi
+  push  Copy dotfiles -> ~/.config/karabiner/karabiner.json and restart Karabiner Elements
+  pull  Copy ~/.config/karabiner/karabiner.json -> dotfiles
+EOF
+}
 
-# Reload Karabiner Elements
-if pgrep -q Karabiner-Elements; then
+resolve_link_target() {
+  local path="$1"
+  if [[ ! -L "$path" ]]; then
+    return 1
+  fi
+
+  local target
+  target="$(readlink "$path")"
+  if [[ "$target" != /* ]]; then
+    target="$(cd "$(dirname "$path")" && cd "$(dirname "$target")" && pwd)/$(basename "$target")"
+  fi
+
+  printf '%s\n' "$target"
+}
+
+restart_karabiner() {
+  if pgrep -q Karabiner-Elements; then
     killall Karabiner-Elements 2>/dev/null || true
     sleep 1
     open /Applications/Karabiner-Elements.app
     echo "✓ Restarted Karabiner Elements"
-else
+  else
     open /Applications/Karabiner-Elements.app
     echo "✓ Started Karabiner Elements"
-fi
+  fi
+}
+
+push_config() {
+  mkdir -p "$(dirname "$KARABINER_DEST")"
+
+  if [[ -L "$KARABINER_DEST" ]]; then
+    local link_target
+    link_target="$(resolve_link_target "$KARABINER_DEST")"
+    if [[ "$link_target" == "$KARABINER_SOURCE" ]]; then
+      echo "✓ karabiner.json already linked to dotfiles"
+      restart_karabiner
+      return 0
+    fi
+
+    echo "Warning: karabiner.json is a symlink to $link_target (skipping overwrite)"
+    return 1
+  fi
+
+  cp "$KARABINER_SOURCE" "$KARABINER_DEST"
+  echo "✓ Synced dotfiles -> Karabiner"
+  restart_karabiner
+}
+
+pull_config() {
+  if [[ ! -e "$KARABINER_DEST" ]]; then
+    echo "Karabiner config not found at $KARABINER_DEST"
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$KARABINER_SOURCE")"
+
+  if [[ -L "$KARABINER_DEST" ]]; then
+    local link_target
+    link_target="$(resolve_link_target "$KARABINER_DEST")"
+    if [[ "$link_target" == "$KARABINER_SOURCE" ]]; then
+      echo "✓ Dotfiles already match the live Karabiner config"
+      return 0
+    fi
+  fi
+
+  cp "$KARABINER_DEST" "$KARABINER_SOURCE"
+  echo "✓ Synced Karabiner -> dotfiles"
+}
+
+case "$MODE" in
+  push)
+    push_config
+    ;;
+  pull)
+    pull_config
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -375,6 +375,7 @@ bb() {
       echo "  bb setup <module>       Install a single module"
       echo "  bb setup hammerspoon    Install Hammerspoon module"
       echo "  bb setup nvim           Install Neovim module"
+      echo "  bb sync karabiner       Sync Karabiner config"
       echo "  bb update               Pull updates and optionally rerun setup"
       echo "  bb backups-clean        Keep only the newest dotfiles backups"
       echo "  bb tmux-clean           Clean detached numeric tmux sessions"
@@ -440,9 +441,9 @@ bb() {
             echo "Karabiner Elements is macOS only."
             return 1
           fi
-          stow -d "$dotfiles_dir/stow-packages" -t "$HOME" karabiner
+          stow -d "$dotfiles_dir/stow-packages" -t "$HOME" karabiner || return 1
           if [[ -x "$dotfiles_dir/scripts/sync-karabiner.sh" ]]; then
-            "$dotfiles_dir/scripts/sync-karabiner.sh"
+            "$dotfiles_dir/scripts/sync-karabiner.sh" push
           else
             echo "Karabiner config stowed. Restart Karabiner Elements to apply."
           fi
@@ -458,6 +459,39 @@ bb() {
         *)
           echo "Unknown module: $module"
           echo "Run: bb help"
+          return 1
+          ;;
+      esac
+      ;;
+    sync)
+      if [[ -z "$dotfiles_dir" || ! -d "$dotfiles_dir" ]]; then
+        echo "Error: Dotfiles directory not found. Set DOTFILES_DIR or run setup first."
+        return 1
+      fi
+
+      if [[ $# -eq 0 ]]; then
+        echo "Usage: bb sync karabiner [push|pull]"
+        return 1
+      fi
+
+      local target="${1:-}"
+      local direction="${2:-pull}"
+
+      case "$target" in
+        karabiner)
+          if [[ "$(uname)" != "Darwin" ]]; then
+            echo "Karabiner Elements is macOS only."
+            return 1
+          fi
+          if [[ ! -x "$dotfiles_dir/scripts/sync-karabiner.sh" ]]; then
+            echo "Karabiner sync script not found."
+            return 1
+          fi
+          "$dotfiles_dir/scripts/sync-karabiner.sh" "$direction"
+          ;;
+        *)
+          echo "Unknown sync target: $target"
+          echo "Usage: bb sync karabiner [push|pull]"
           return 1
           ;;
       esac

--- a/tests/karabiner_module.test.ts
+++ b/tests/karabiner_module.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf-8');
+}
+
+describe('Karabiner module wiring', () => {
+  it('keeps a stowable Karabiner config in the repo', () => {
+    expect(fs.existsSync(path.join(repoRoot, 'stow-packages/karabiner/.config/karabiner/karabiner.json'))).toBe(true);
+  });
+
+  it('supports both push and pull sync directions', () => {
+    const script = readRepoFile('scripts/sync-karabiner.sh');
+    expect(script).toContain('Usage: ./scripts/sync-karabiner.sh [push|pull]');
+    expect(script).toContain('push_config()');
+    expect(script).toContain('pull_config()');
+    expect(script).toContain('Synced Karabiner -> dotfiles');
+    expect(script).toContain('Synced dotfiles -> Karabiner');
+  });
+
+  it('exposes bb sync karabiner helper command', () => {
+    const functionsSh = readRepoFile('shell/functions.sh');
+    expect(functionsSh).toContain('bb sync karabiner');
+    expect(functionsSh).toContain('Usage: bb sync karabiner [push|pull]');
+    expect(functionsSh).toContain('"$dotfiles_dir/scripts/sync-karabiner.sh" "$direction"');
+  });
+
+  it('documents how to import the live machine config', () => {
+    const readme = readRepoFile('README.md');
+    const docs = readRepoFile('docs/modules/karabiner.md');
+
+    expect(readme).toContain('bb sync karabiner pull');
+    expect(docs).toContain('./scripts/sync-karabiner.sh push');
+    expect(docs).toContain('./scripts/sync-karabiner.sh pull');
+    expect(docs).toContain('bb sync karabiner pull');
+  });
+});


### PR DESCRIPTION
This adds explicit push and pull modes for Karabiner sync so the repo can either install the tracked config or import the live machine config back into dotfiles. It also adds a new `bb sync karabiner [push|pull]` helper, updates the Karabiner docs/README to document the reverse-sync flow, and adds tests covering the script and shell wiring. Validation: `pnpm test` passed.