### PR TITLE
fix: stop stowed sesh binary from breaking tmux on macOS

### DIFF
--- a/stow-packages/tmux/.config/tmux/sesh-picker.sh
+++ b/stow-packages/tmux/.config/tmux/sesh-picker.sh
@@ -1,17 +1,24 @@
 #!/usr/bin/env bash
-sesh connect "$(
-  sesh list --icons --hide-duplicates | fzf-tmux -p 80%,70% \
+
+# tmux resolves `sesh` to a stale non-macOS binary in ~/.local/bin on this host.
+sesh_bin="${HOMEBREW_PREFIX:-/opt/homebrew}/bin/sesh"
+if [[ ! -x "$sesh_bin" ]]; then
+  sesh_bin="$(command -v sesh)"
+fi
+
+"$sesh_bin" connect "$(
+  "$sesh_bin" list --icons --hide-duplicates | fzf-tmux -p 80%,70% \
     --no-sort --ansi --disabled \
     --border-label ' sesh ' --prompt '⚡  ' \
     --header '  j/k nav  / search  esc close/nav  enter select  x kill  ^a all  ^t tmux  ^g configs  ^x zoxide' \
     --bind 'j:down,k:up' \
     --bind '/:enable-search+change-prompt(🔍  )+unbind(j,k)+unbind(esc)' \
     --bind 'esc:abort' \
-    --bind 'x:execute(tmux kill-session -t {2..})+reload(sesh list --icons --hide-duplicates)' \
-    --bind 'ctrl-a:disable-search+change-prompt(⚡  )+rebind(j,k,esc)+reload(sesh list --icons --hide-duplicates)' \
-    --bind 'ctrl-t:disable-search+change-prompt(🪟  )+rebind(j,k,esc)+reload(sesh list -t --icons)' \
-    --bind 'ctrl-g:disable-search+change-prompt(⚙️  )+rebind(j,k,esc)+reload(sesh list -c --icons)' \
-    --bind 'ctrl-x:disable-search+change-prompt(📁  )+rebind(j,k,esc)+reload(sesh list -z --icons)' \
+    --bind "x:execute(tmux kill-session -t {2..})+reload($sesh_bin list --icons --hide-duplicates)" \
+    --bind "ctrl-a:disable-search+change-prompt(⚡  )+rebind(j,k,esc)+reload($sesh_bin list --icons --hide-duplicates)" \
+    --bind "ctrl-t:disable-search+change-prompt(🪟  )+rebind(j,k,esc)+reload($sesh_bin list -t --icons)" \
+    --bind "ctrl-g:disable-search+change-prompt(⚙️  )+rebind(j,k,esc)+reload($sesh_bin list -c --icons)" \
+    --bind "ctrl-x:disable-search+change-prompt(📁  )+rebind(j,k,esc)+reload($sesh_bin list -z --icons)" \
     --preview-window 'right:55%' \
-    --preview 'echo "Windows:" && tmux list-windows -t {2..} -F " #I: #W (#{window_panes} panes)" && echo "\nPreview:" && sesh preview {2..}'
+    --preview "echo \"Windows:\" && tmux list-windows -t {2..} -F \" #I: #W (#{window_panes} panes)\" && echo \"\\nPreview:\" && $sesh_bin preview {2..}"
 )"

--- a/tests/tmux_sesh_behavior.test.ts
+++ b/tests/tmux_sesh_behavior.test.ts
@@ -8,7 +8,9 @@ describe("tmux and sesh workflow", () => {
   const functionsSh = readFileSync(join(process.cwd(), "shell", "functions.sh"), "utf-8");
   const aliasesSh = readFileSync(join(process.cwd(), "shell", "aliases.sh"), "utf-8");
   const tmuxSmartPath = join(process.cwd(), "stow-packages", "tmux", ".local", "bin", "tmux-smart");
+  const seshShimPath = join(process.cwd(), "stow-packages", "tmux", ".local", "bin", "sesh");
   const tmuxSmartSh = readFileSync(tmuxSmartPath, "utf-8");
+  const seshShimSh = readFileSync(seshShimPath, "utf-8");
   const seshPickerSh = readFileSync(
     join(process.cwd(), "stow-packages", "tmux", ".config", "tmux", "sesh-picker.sh"),
     "utf-8",
@@ -217,9 +219,40 @@ exit 1
   });
 
   it("keeps the current search query when entering fuzzy mode", () => {
-    expect(seshPickerSh).toContain("sesh list --icons --hide-duplicates");
+    expect(seshPickerSh).toContain('"$sesh_bin" list --icons --hide-duplicates');
     expect(seshPickerSh).toContain("/:enable-search+change-prompt(🔍  )+unbind(j,k)+unbind(esc)");
     expect(seshPickerSh).not.toContain("clear-query");
+  });
+
+  it("prefers a real sesh binary over the stowed shim", () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), "sesh-shim-"));
+    const brewPrefix = join(fixtureDir, "brew");
+    const brewBin = join(brewPrefix, "bin");
+    const outputPath = join(fixtureDir, "args.log");
+    tempDirs.push(fixtureDir);
+    mkdirSync(brewBin, { recursive: true });
+
+    createExecutable(
+      brewBin,
+      "sesh",
+      `#!/usr/bin/env bash
+printf '%s\n' "$*" > "${outputPath}"
+`,
+    );
+
+    const result = spawnSync(seshShimPath, ["list", "--icons"], {
+      cwd: fixtureDir,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOMEBREW_PREFIX: brewPrefix,
+        PATH: `${join(process.cwd(), "stow-packages", "tmux", ".local", "bin")}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(outputPath, "utf-8")).toContain("list --icons");
+    expect(seshShimSh).toContain('which -a sesh');
   });
 
   it("adds bb tmux-clean command for stale detached sessions", () => {


### PR DESCRIPTION
## Summary
- replace the stowed `~/.local/bin/sesh` Linux binary with a portable shim that forwards to a real installed `sesh` binary
- update the tmux sesh picker to use the resolved native binary for connect, reload, and preview actions
- add tests covering the shim behavior and the updated picker command resolution

## Testing
- `pnpm test`