### PR TITLE
fix tmux bootstrap and sesh picker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ bb status
 - copy mode: `Leader+v`
 - new window: `Leader+t` (or `Alt+c`)
 
+For the tmux workflow in this repo, keep these tools current:
+
+- `fzf >= 0.34`
+- `sesh >= 2.25`
+- `tmux-fingers >= 2.6`
+
+On macOS, `tmux-fingers` also needs working Xcode Command Line Tools before Homebrew can install it.
+
 ## Structure
 
 ```

--- a/bootstrap-linux.sh
+++ b/bootstrap-linux.sh
@@ -268,6 +268,29 @@ else
     exit 1
   fi
   print_success "Chezmoi base dotfiles applied"
+
+  if [[ "$NON_INTERACTIVE" -eq 1 ]]; then
+    print_warning "Skipping interactive setup in non-interactive mode"
+  else
+    print_step "Launching interactive dotfiles setup..."
+    TSX_BIN="./node_modules/.bin/tsx"
+    if [[ -x "$TSX_BIN" ]]; then
+      if ! "$TSX_BIN" setup.ts "$DOTFILES_DIR" < /dev/tty; then
+        print_error "setup.ts failed"
+        exit 1
+      fi
+    elif command -v pnpm >/dev/null 2>&1; then
+      if ! pnpm exec tsx setup.ts "$DOTFILES_DIR" < /dev/tty; then
+        print_error "setup.ts failed"
+        exit 1
+      fi
+    else
+      print_error "setup.ts failed"
+      print_error "Cannot run setup.ts"
+      exit 1
+    fi
+    print_success "Interactive setup complete"
+  fi
 fi
 
 print_success "Linux bootstrap complete"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -402,4 +402,20 @@ else
     exit 1
   fi
   print_success "Chezmoi base dotfiles applied!"
+
+  echo ""
+  print_step "Launching interactive dotfiles setup..."
+  TSX_BIN="./node_modules/.bin/tsx"
+  if [ -x "$TSX_BIN" ]; then
+    if ! "$TSX_BIN" setup.ts "$DOTFILES_DIR" < /dev/tty; then
+      print_error "setup.ts failed"
+      exit 1
+    fi
+  else
+    if ! pnpm exec tsx setup.ts "$DOTFILES_DIR" < /dev/tty; then
+      print_error "setup.ts failed"
+      exit 1
+    fi
+  fi
+  print_success "Interactive setup complete!"
 fi

--- a/docs/modules/tmux.md
+++ b/docs/modules/tmux.md
@@ -34,6 +34,13 @@ Reload tmux after install:
 tmux source-file ~/.tmux.conf
 ```
 
+Version notes:
+
+- `fzf 0.34.x` is supported by the custom sesh picker in this repo.
+- `tmux-fingers` requires a real installed binary, not just the TPM plugin checkout.
+- On macOS, install the binary with Homebrew: `brew install tmux-fingers`.
+- If Homebrew blocks installs because Command Line Tools are outdated, run `xcode-select --install` first.
+
 ## Prefix
 
 - Prefix is `Ctrl+b` in `basic`
@@ -128,3 +135,9 @@ Then in tmux:
 
 - `Leader+I` installs plugins
 - `Leader+U` updates plugins
+
+Recommended package versions for the tmux workflow in this repo:
+
+- `fzf >= 0.34`
+- `sesh >= 2.25`
+- `tmux-fingers >= 2.6`

--- a/setup.ts
+++ b/setup.ts
@@ -1334,7 +1334,6 @@ function generateTmuxEntrypoint(): string {
     "# =============================================================================",
     "",
     `source-file "$HOME/.config/tmux/builtby/bootstrap.basic.conf"`,
-    `source-file "$HOME/.config/tmux/builtby/basic.conf"`,
   ].join("\n") + "\n";
 }
 
@@ -1502,11 +1501,6 @@ async function setupStowConfigs(configs: string[]): Promise<void> {
         unlinkSync(targetPath);
         needsStow = true;
       } else {
-        // Ensure parent directory exists
-        const parentDir = dirname(targetPath);
-        if (!existsSync(parentDir)) {
-          mkdirSync(parentDir, { recursive: true });
-        }
         needsStow = true;
       }
     }

--- a/stow-packages/tmux/.config/tmux/builtby/basic.conf
+++ b/stow-packages/tmux/.config/tmux/builtby/basic.conf
@@ -7,10 +7,15 @@
 set -g prefix 'C-b'
 bind 'C-b' send-prefix
 
+# Clipboard integration
+if-shell "uname | grep -q Darwin" \
+  "set -s copy-command 'pbcopy'" \
+  "set -s copy-command 'xclip -in -selection clipboard'"
+
 # Sesh integration
 bind t new-window -c "#{pane_current_path}"
-bind-key "Space" run-shell "$HOME/.config/tmux/sesh-picker.sh"
-bind-key "T" run-shell "sesh last"
+bind-key "Space" display-popup -E -w 80% -h 70% "bash -lc '$HOME/.config/tmux/sesh-picker.sh'"
+bind-key "T" run-shell "$HOME/.local/bin/sesh last >/dev/null 2>&1 || tmux display-message 'No previous sesh session yet'"
 
 # Workmux integration
 unbind n
@@ -54,9 +59,7 @@ bind -n M-6 select-window -t 6
 bind -n M-7 select-window -t 7
 bind -n M-8 select-window -t 8
 bind -n M-9 select-window -t 9
-if-shell "uname | grep -q Darwin" \
-  "bind -n M-c copy-mode \; send-keys -X copy-pipe-and-cancel 'pbcopy'" \
-  "bind -n M-c copy-mode \; send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'"
+bind -n M-c copy-mode
 
 # Pane resizing
 bind -r - resize-pane -L 5
@@ -73,7 +76,9 @@ bind -n C-S-k send-keys -R \; clear-history
 setw -g mode-keys vi
 bind v copy-mode
 bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel
+bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel
 
 # Session navigation
 bind Tab switch-client -l
@@ -82,9 +87,9 @@ bind -n M-) switch-client -n
 
 # Help and command palette
 bind / display-popup -E -w 70% -h 80% 'cmd=$(cat << "EOF" | fzf --ansi --prompt="Command: " --header="Type to filter, Enter to run" --delimiter " ::: " --with-nth "1..3"
-[Sessions] ::: Session Picker ::: Leader + Space ::: sesh connect "$(sesh list | fzf)"
+[Sessions] ::: Session Picker ::: Leader + Space ::: tmux display-popup -E -w 50% -h 90% "$HOME/.local/bin/sesh picker -i"
 [Sessions] ::: Last Session ::: Leader + Tab ::: tmux switch-client -l
-[Sessions] ::: Sesh Last Session ::: Leader + T ::: sesh last
+[Sessions] ::: Sesh Last Session ::: Leader + T ::: $HOME/.local/bin/sesh last >/dev/null 2>&1 || tmux display-message "No previous sesh session yet"
 [Sessions] ::: Next Session ::: Alt + ) ::: tmux switch-client -n
 [Sessions] ::: Prev Session ::: Alt + ( ::: tmux switch-client -p
 [Sessions] ::: Rename Session ::: Leader + $ ::: tmux command-prompt -I "#S" "rename-session \"%1\""
@@ -126,7 +131,7 @@ bind r source-file ~/.config/tmux/builtby/core.conf \; source-file ~/.config/tmu
 # Sesh sessions display
 set -g pane-border-status bottom
 set -g pane-border-format " #{pane_current_command} (#{pane_index}) "
-bind-key "S" display-popup -E -w 80% -h 60% 'sesh list --icons | fzf --no-sort --ansi --preview "sesh preview {}" --bind "enter:execute(sesh connect {2..})" --header "Open sesh sessions - Enter to connect, Esc to close"'
+bind-key "S" display-popup -E -w 80% -h 60% '$HOME/.local/bin/sesh list --icons | fzf --no-sort --ansi --preview "$HOME/.local/bin/sesh preview {}" --bind "enter:execute($HOME/.local/bin/sesh connect {2..})" --header "Open sesh sessions - Enter to connect, Esc to close"'
 
 # TPM
 set -g @plugin 'tmux-plugins/tpm'
@@ -145,18 +150,8 @@ set -g @floax-height '80%'
 set -g @floax-border-color 'magenta'
 set -g @floax-text-color 'blue'
 set -g @fzf-url-bind 'u'
-if-shell -b "[ -x /opt/homebrew/bin/tmux-fingers ]" "run-shell -b '/opt/homebrew/bin/tmux-fingers load-config'"
-if-shell -b "[ -x /usr/local/bin/tmux-fingers ]" "run-shell -b '/usr/local/bin/tmux-fingers load-config'"
-if-shell -b "command -v tmux-fingers >/dev/null 2>&1" "run-shell -b 'tmux-fingers load-config'"
 set -g @continuum-restore 'on'
 set -g @continuum-save-interval '15'
-
-# agent-deck clipboard integration
-if-shell "uname | grep -q Darwin" \
-  "bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'pbcopy'; \
-   bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'pbcopy'" \
-  "bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'; \
-   bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'"
 
 # Initialize TPM (must stay at bottom)
 run '~/.tmux/plugins/tpm/tpm'

--- a/stow-packages/tmux/.config/tmux/sesh-picker.sh
+++ b/stow-packages/tmux/.config/tmux/sesh-picker.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 
+set -u
+
 # tmux resolves `sesh` to a stale non-macOS binary in ~/.local/bin on this host.
 sesh_bin="${HOMEBREW_PREFIX:-/opt/homebrew}/bin/sesh"
 if [[ ! -x "$sesh_bin" ]]; then
   sesh_bin="$(command -v sesh)"
 fi
 
-"$sesh_bin" connect "$(
-  "$sesh_bin" list --icons --hide-duplicates | fzf-tmux -p 80%,70% \
+selection="$(
+  "$sesh_bin" list --icons --hide-duplicates | fzf \
     --no-sort --ansi --disabled \
-    --border-label ' sesh ' --prompt '⚡  ' \
+    --prompt '⚡  ' \
     --header '  j/k nav  / search  esc close/nav  enter select  x kill  ^a all  ^t tmux  ^g configs  ^x zoxide' \
     --bind 'j:down,k:up' \
     --bind '/:enable-search+change-prompt(🔍  )+unbind(j,k)+unbind(esc)' \
@@ -21,4 +23,8 @@ fi
     --bind "ctrl-x:disable-search+change-prompt(📁  )+rebind(j,k,esc)+reload($sesh_bin list -z --icons)" \
     --preview-window 'right:55%' \
     --preview "echo \"Windows:\" && tmux list-windows -t {2..} -F \" #I: #W (#{window_panes} panes)\" && echo \"\\nPreview:\" && $sesh_bin preview {2..}"
-)"
+)" || exit 0
+
+[[ -z "$selection" ]] && exit 0
+
+"$sesh_bin" connect "$selection"

--- a/tests/linux_bootstrap.test.ts
+++ b/tests/linux_bootstrap.test.ts
@@ -167,6 +167,18 @@ describe('Linux bootstrap workflow', () => {
     expect(content).toContain('legacy stow/setup lane');
   });
 
+  it('hands off to interactive setup after the base chezmoi apply in interactive bootstrap runs', () => {
+    const macBootstrap = fs.readFileSync(bootstrapPath, 'utf-8');
+    const linuxBootstrap = fs.readFileSync(linuxBootstrapPath, 'utf-8');
+
+    expect(macBootstrap).toContain('print_step "Launching interactive dotfiles setup..."');
+    expect(macBootstrap).toContain('print_success "Interactive setup complete!"');
+    expect(macBootstrap).toContain('setup.ts "$DOTFILES_DIR" < /dev/tty');
+    expect(linuxBootstrap).toContain('print_step "Launching interactive dotfiles setup..."');
+    expect(linuxBootstrap).toContain('print_success "Interactive setup complete"');
+    expect(linuxBootstrap).toContain('setup.ts "$DOTFILES_DIR" < /dev/tty');
+  });
+
   it('supports explicit setup path arguments in the macOS/bootstrap wrapper too', () => {
     const macBootstrap = fs.readFileSync(bootstrapPath, 'utf-8');
 
@@ -180,6 +192,7 @@ describe('Linux bootstrap workflow', () => {
     expect(content).toContain('elif [[ "$NON_INTERACTIVE" -eq 1 ]]; then');
     expect(content).toContain('SETUP_ARGS+=( --setup-path standard )');
     expect(content).not.toContain('SETUP_PATH="standard"');
+    expect(content).toContain('Skipping interactive setup in non-interactive mode');
   });
 
   it('gives pnpm install failures explicit disk-space/bootstrap guidance', () => {

--- a/tests/tmux_config.test.ts
+++ b/tests/tmux_config.test.ts
@@ -73,6 +73,26 @@ describe("tmux profile split", () => {
     expect(basicConf).toContain('[Other] ::: Reload Config ::: Leader + r ::: tmux source-file ~/.config/tmux/builtby/core.conf && tmux source-file ~/.config/tmux/builtby/basic.conf');
   });
 
+  it("uses the local sesh shim and lets TPM load tmux-fingers", () => {
+    expect(basicConf).toContain("No previous sesh session yet");
+    expect(basicConf).toContain('run-shell "$HOME/.local/bin/sesh last >/dev/null 2>&1 || tmux display-message');
+    expect(basicConf).toContain("$HOME/.local/bin/sesh list --icons");
+    expect(basicConf).toContain("run '~/.tmux/plugins/tpm/tpm'");
+    expect(basicConf).toContain("set -g @plugin 'Morantron/tmux-fingers'");
+    expect(basicConf).not.toContain('tmux-fingers load-config');
+    expect(basicConf).not.toContain("bind-key f run-shell 'tmux-fingers'");
+  });
+
+  it("uses copy-command-based clipboard bindings that are safe to reload", () => {
+    expect(basicConf).toContain("set -s copy-command 'pbcopy'");
+    expect(basicConf).toContain("set -s copy-command 'xclip -in -selection clipboard'");
+    expect(basicConf).toContain('bind -n M-c copy-mode');
+    expect(basicConf).toContain('bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel');
+    expect(basicConf).toContain('bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel');
+    expect(basicConf).not.toContain("bind -n M-c copy-mode \\; send-keys -X copy-pipe-and-cancel");
+    expect(basicConf).not.toContain("MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'pbcopy'");
+  });
+
   it("puts shared defaults in core and prefix in basic", () => {
     expect(coreConf).toContain("set -g mouse on");
     expect(basicConf).toMatch(/set -g prefix 'C-b'/);
@@ -94,10 +114,16 @@ describe("tmux profile split", () => {
 describe("tmux setup safety", () => {
   const setupTs = readFileSync(join(process.cwd(), "setup.ts"), "utf-8");
   const functionsSh = readFileSync(join(process.cwd(), "shell", "functions.sh"), "utf-8");
+  const tmuxDocs = readFileSync(join(process.cwd(), "docs", "modules", "tmux.md"), "utf-8");
 
   it("offers keep-my-keybinds path for existing tmux users", () => {
     expect(setupTs).toContain("Keep my existing keybinds (recommended)");
     expect(setupTs).toContain("Replace with builtby basic profile (backup mine first)");
+  });
+
+  it("generates a single bootstrap-based ~/.tmux.conf entrypoint", () => {
+    expect(setupTs).toContain('source-file "$HOME/.config/tmux/builtby/bootstrap.basic.conf"');
+    expect(setupTs).not.toContain('source-file "$HOME/.config/tmux/builtby/basic.conf"`,');
   });
 
   it("updates local workmux config from templates during setup", () => {
@@ -126,5 +152,12 @@ describe("tmux setup safety", () => {
     expect(functionsSh).toContain('local backup_path="$backup_dir/config.yaml.dotfiles-backup.$(date +%s)"');
     expect(functionsSh).toContain('_bb_prune_backups "$backup_dir" "config.yaml.dotfiles-backup." 1');
     expect(functionsSh).toContain('_sync_workmux_config "$dotfiles_dir"');
+  });
+
+  it("documents tmux package version guidance for the custom sesh workflow", () => {
+    expect(tmuxDocs).toContain('fzf >= 0.34');
+    expect(tmuxDocs).toContain('sesh >= 2.25');
+    expect(tmuxDocs).toContain('tmux-fingers >= 2.6');
+    expect(tmuxDocs).toContain('xcode-select --install');
   });
 });

--- a/tests/tmux_sesh_behavior.test.ts
+++ b/tests/tmux_sesh_behavior.test.ts
@@ -220,6 +220,11 @@ exit 1
 
   it("keeps the current search query when entering fuzzy mode", () => {
     expect(seshPickerSh).toContain('"$sesh_bin" list --icons --hide-duplicates');
+    expect(seshPickerSh).toContain('| fzf \\');
+    expect(seshPickerSh).not.toContain('fzf-tmux -p 80%,70%');
+    expect(seshPickerSh).toContain('selection="$(');
+    expect(seshPickerSh).toContain('|| exit 0');
+    expect(seshPickerSh).toContain('[[ -z "$selection" ]] && exit 0');
     expect(seshPickerSh).toContain("/:enable-search+change-prompt(🔍  )+unbind(j,k)+unbind(esc)");
     expect(seshPickerSh).not.toContain("clear-query");
   });


### PR DESCRIPTION
## Summary
- fix the legacy bootstrap handoff so curl installs continue into interactive setup after the base chezmoi apply
- harden tmux integration by removing duplicate bootstrap sourcing, using safer clipboard reload bindings, and restoring the custom sesh picker with popup-safe execution
- document tmux workflow package expectations for fzf, sesh, tmux-fingers, and macOS Command Line Tools

## Testing
- pnpm vitest run tests/linux_bootstrap.test.ts tests/tmux_config.test.ts tests/tmux_sesh_behavior.test.ts