### PR TITLE
feat: opencode theming + macOS app export sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This is ideal if you want to add pieces over time.
 | Hammerspoon | `bb setup hammerspoon` | Hyper app launcher + Ghostty 4-pane hotkey | `docs/modules/hammerspoon.md` |
 | Karabiner | `bb setup karabiner` | macOS only, jk to tmux prefix, `bb sync karabiner pull` imports live config | `docs/modules/karabiner.md` |
 | Ghostty | `bb setup ghostty` | terminal config | `docs/modules/ghostty.md` |
-| App backups | `bb restore macos-apps` | Raycast, Rectangle Pro, BetterTouchTool exports | `docs/modules/app-backups.md` |
+| App backups | `bb sync macos-apps pull` | Raycast, Rectangle Pro, BetterTouchTool export sync + restore | `docs/modules/app-backups.md` |
 | AI configs | `bb setup` | auto-copied from templates | `docs/modules/ai.md` |
 | Back2Vibing | `bb setup back2vibing` | Focus & productivity for AI devs | `back2vibing.builtby.win` |
 
@@ -187,7 +187,16 @@ Native app exports live under `assets/app-exports/`:
 - `assets/app-exports/rectangle-pro/`
 - `assets/app-exports/bettertouchtool/`
 
-Restore helpers:
+Sync the latest machine exports back into the repo:
+
+```bash
+bb sync macos-apps pull
+bb sync raycast pull
+bb sync rectangle-pro pull
+bb sync bettertouchtool pull
+```
+
+Reveal/import the repo copies:
 
 ```bash
 bb restore macos-apps
@@ -195,6 +204,8 @@ bb restore raycast
 bb restore rectangle-pro
 bb restore bettertouchtool
 ```
+
+OpenCode styling is copy-managed from `templates/opencode/`. See `docs/modules/opencode.md`.
 
 ## Manual setup (if you prefer)
 

--- a/chezmoi/dot_config/neru/config.toml
+++ b/chezmoi/dot_config/neru/config.toml
@@ -1,4 +1,8 @@
 [hotkeys]
+"Primary+Shift+Space" = "__disabled__"
+"Primary+Shift+G" = "__disabled__"
+"Primary+Shift+C" = "__disabled__"
+"Primary+Shift+S" = "__disabled__"
 "Cmd+Ctrl+Alt+Shift+K" = "scroll"
 "Cmd+Ctrl+Alt+Shift+L" = "grid --cursor-selection-mode follow"
 "Cmd+Ctrl+Alt+Shift+;" = "hints"

--- a/docs/modules/app-backups.md
+++ b/docs/modules/app-backups.md
@@ -8,6 +8,21 @@ This repo keeps native restore artifacts for apps that should be restored throug
 - `assets/app-exports/rectangle-pro/RectangleProConfig.json`
 - `assets/app-exports/bettertouchtool/Default.bttpreset`
 
+## Sync helpers
+
+Pull the latest machine exports into the repo:
+
+```bash
+bb sync macos-apps pull
+bb sync raycast pull
+bb sync rectangle-pro pull
+bb sync bettertouchtool pull
+```
+
+For Raycast, export a backup first so a fresh `Raycast-*.rayconfig` file lands in `~/Downloads`.
+
+For Rectangle Pro and BetterTouchTool, export their config/preset from the app first, then rerun sync.
+
 ## Restore helpers
 
 Reveal all app exports and print the restore steps:

--- a/docs/modules/chezmoi.md
+++ b/docs/modules/chezmoi.md
@@ -38,10 +38,11 @@ bb setup tmux
 bb setup ghostty
 ```
 
-5. Restore macOS app exports separately:
+5. Sync or restore macOS app exports separately:
 
 ```bash
+bb sync macos-apps pull
 bb restore macos-apps
 ```
 
-That command reveals the versioned exports and prints the import path for each app.
+The sync command copies fresh exports into the repo. The restore command reveals the versioned exports and prints the import path for each app.

--- a/docs/modules/opencode.md
+++ b/docs/modules/opencode.md
@@ -1,0 +1,25 @@
+# OpenCode
+
+OpenCode config is copy-managed from `templates/opencode/` because the tool owns its local files.
+
+## Files
+
+- `templates/opencode/opencode.json`
+- `templates/opencode/oh-my-openagent.json`
+- `templates/opencode/tui.json`
+
+## Current styling
+
+The repo keeps OpenCode on a cool blue palette so it visually matches the newer `neru` theme direction. Oh My OpenAgent is configured with GPT-5.5 for most reasoning paths and GPT-5.4 Mini for implementation/fast execution paths.
+
+## Apply
+
+Run the interactive setup and select OpenCode, or re-run setup if it is already enabled:
+
+```bash
+bb setup
+```
+
+## Sync workflow
+
+If you tweak OpenCode locally and want those changes versioned here, copy the updated files back into `templates/opencode/` and commit them.

--- a/scripts/sync-macos-app-backups.sh
+++ b/scripts/sync-macos-app-backups.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Sync macOS app export artifacts between dotfiles and the live machine.
+
+set -euo pipefail
+
+MODE="${1:-pull}"
+TARGET="${2:-macos-apps}"
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_EXPORTS_DIR="$DOTFILES_DIR/assets/app-exports"
+RAYCAST_REPO_DIR="$APP_EXPORTS_DIR/raycast/archive"
+RECTANGLE_REPO_PATH="$APP_EXPORTS_DIR/rectangle-pro/RectangleProConfig.json"
+BTT_REPO_PATH="$APP_EXPORTS_DIR/bettertouchtool/Default.bttpreset"
+
+RAYCAST_SOURCE_DIR="$HOME/Downloads"
+RECTANGLE_SOURCE_PATH="$HOME/Library/Application Support/Rectangle Pro/RectangleProConfig.json"
+BTT_SOURCE_PATH="$HOME/Library/Application Support/BetterTouchTool/bttdata/Default.bttpreset"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/sync-macos-app-backups.sh [pull|push] [target]
+
+  pull  Copy live machine exports -> dotfiles
+  push  Reveal dotfiles exports and print import instructions
+
+Targets:
+  raycast, rectangle-pro, bettertouchtool, macos-apps
+EOF
+}
+
+ensure_parent_dir() {
+  mkdir -p "$1"
+}
+
+latest_raycast_export() {
+  if [[ ! -d "$RAYCAST_SOURCE_DIR" ]]; then
+    return 1
+  fi
+
+  local latest_file
+  latest_file="$(ls -t "$RAYCAST_SOURCE_DIR"/Raycast-*.rayconfig 2>/dev/null | head -n 1 || true)"
+  if [[ -z "$latest_file" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$latest_file"
+}
+
+latest_repo_raycast_export() {
+  if [[ ! -d "$RAYCAST_REPO_DIR" ]]; then
+    return 1
+  fi
+
+  local latest_file
+  latest_file="$(ls -t "$RAYCAST_REPO_DIR"/Raycast-*.rayconfig 2>/dev/null | head -n 1 || true)"
+  if [[ -z "$latest_file" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$latest_file"
+}
+
+copy_with_notice() {
+  local source_path="$1"
+  local dest_path="$2"
+  cp "$source_path" "$dest_path"
+  echo "✓ Synced $(basename "$source_path") -> $dest_path"
+}
+
+reveal_file() {
+  local file_path="$1"
+  if [[ ! -f "$file_path" ]]; then
+    echo "Missing export: $file_path"
+    return 1
+  fi
+
+  if [[ "$(uname)" == "Darwin" ]]; then
+    open -R "$file_path"
+  fi
+
+  echo "  $file_path"
+}
+
+pull_raycast() {
+  local source_path
+  source_path="$(latest_raycast_export)" || {
+    echo "Raycast export not found. Export a .rayconfig file to Downloads first."
+    return 1
+  }
+
+  ensure_parent_dir "$RAYCAST_REPO_DIR"
+  local dest_path="$RAYCAST_REPO_DIR/$(basename "$source_path")"
+  copy_with_notice "$source_path" "$dest_path"
+}
+
+pull_rectangle() {
+  if [[ ! -f "$RECTANGLE_SOURCE_PATH" ]]; then
+    echo "Rectangle Pro config not found: $RECTANGLE_SOURCE_PATH"
+    echo "Export Rectangle Pro config first, then rerun sync."
+    return 1
+  fi
+
+  ensure_parent_dir "$(dirname "$RECTANGLE_REPO_PATH")"
+  copy_with_notice "$RECTANGLE_SOURCE_PATH" "$RECTANGLE_REPO_PATH"
+}
+
+pull_btt() {
+  if [[ ! -f "$BTT_SOURCE_PATH" ]]; then
+    echo "BetterTouchTool preset not found: $BTT_SOURCE_PATH"
+    echo "Export the Default preset first, then rerun sync."
+    return 1
+  fi
+
+  ensure_parent_dir "$(dirname "$BTT_REPO_PATH")"
+  copy_with_notice "$BTT_SOURCE_PATH" "$BTT_REPO_PATH"
+}
+
+push_raycast() {
+  local file_path
+  file_path="$(latest_repo_raycast_export)" || {
+    echo "Raycast export not found in repo: $RAYCAST_REPO_DIR"
+    return 1
+  }
+
+  echo "Raycast export:"
+  reveal_file "$file_path"
+  echo "Import in Raycast using Preferences -> Advanced -> Import Backup."
+}
+
+push_rectangle() {
+  echo "Rectangle Pro export:"
+  reveal_file "$RECTANGLE_REPO_PATH"
+  echo "Import in Rectangle Pro from its settings/preferences import flow."
+}
+
+push_btt() {
+  echo "BetterTouchTool export:"
+  reveal_file "$BTT_REPO_PATH"
+  echo "Import in BetterTouchTool via preset restore/import."
+}
+
+run_target() {
+  local mode="$1"
+  local target="$2"
+
+  case "$target" in
+    macos-apps|all)
+      "${mode}_raycast"
+      echo
+      "${mode}_rectangle"
+      echo
+      "${mode}_btt"
+      ;;
+    raycast)
+      "${mode}_raycast"
+      ;;
+    rectangle|rectangle-pro)
+      "${mode}_rectangle"
+      ;;
+    bettertouchtool|btt)
+      "${mode}_btt"
+      ;;
+    *)
+      echo "Unknown target: $target"
+      echo "Valid targets: raycast, rectangle-pro, bettertouchtool, macos-apps"
+      return 1
+      ;;
+  esac
+}
+
+case "$MODE" in
+  pull)
+    run_target pull "$TARGET"
+    ;;
+  push)
+    run_target push "$TARGET"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/setup.ts
+++ b/setup.ts
@@ -557,7 +557,7 @@ const AI_CONFIGS: Record<string, { name: string; templates: string[]; targetDir?
   },
   opencode: {
     name: "OpenCode",
-    templates: ["opencode.json", "tui.json"],
+    templates: ["opencode.json", "oh-my-openagent.json", "tui.json"],
     targetDir: ".config/opencode",
   },
   gemini: {

--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -383,6 +383,7 @@ bb() {
       echo "  bb setup hammerspoon    Install Hammerspoon module"
       echo "  bb setup nvim           Install Neovim module"
       echo "  bb sync karabiner       Sync Karabiner config"
+      echo "  bb sync macos-apps      Sync Raycast/Rectangle/BTT exports"
       echo "  bb restore <target>     Reveal macOS app backup exports"
       echo "  bb update               Pull updates and optionally rerun setup"
       echo "  bb backups-clean        Keep only the newest dotfiles backups"
@@ -490,7 +491,8 @@ bb() {
       fi
 
       if [[ $# -eq 0 ]]; then
-        echo "Usage: bb sync karabiner [push|pull]"
+        echo "Usage: bb sync <target> [push|pull]"
+        echo "Targets: karabiner, raycast, rectangle-pro, bettertouchtool, macos-apps"
         return 1
       fi
 
@@ -509,9 +511,21 @@ bb() {
           fi
           "$dotfiles_dir/scripts/sync-karabiner.sh" "$direction"
           ;;
+        raycast|rectangle|rectangle-pro|bettertouchtool|btt|macos-apps)
+          if [[ "$(uname)" != "Darwin" ]]; then
+            echo "macOS app export sync is macOS only."
+            return 1
+          fi
+          if [[ ! -x "$dotfiles_dir/scripts/sync-macos-app-backups.sh" ]]; then
+            echo "macOS app sync script not found."
+            return 1
+          fi
+          "$dotfiles_dir/scripts/sync-macos-app-backups.sh" "$direction" "$target"
+          ;;
         *)
           echo "Unknown sync target: $target"
-          echo "Usage: bb sync karabiner [push|pull]"
+          echo "Usage: bb sync <target> [push|pull]"
+          echo "Targets: karabiner, raycast, rectangle-pro, bettertouchtool, macos-apps"
           return 1
           ;;
       esac

--- a/stow-packages/tmux/.local/bin/claude
+++ b/stow-packages/tmux/.local/bin/claude
@@ -1,1 +1,1 @@
-/home/winston/.local/share/claude/versions/2.1.79
+/Users/winstonzhao/.local/share/claude/versions/2.1.119

--- a/stow-packages/tmux/.local/bin/comment-checker
+++ b/stow-packages/tmux/.local/bin/comment-checker
@@ -1,0 +1,1 @@
+/Users/winstonzhao/.local/share/fnm/node-versions/v24.15.0/installation/lib/node_modules/@code-yeongyu/comment-checker/bin/comment-checker

--- a/templates/opencode/oh-my-openagent.json
+++ b/templates/opencode/oh-my-openagent.json
@@ -1,0 +1,300 @@
+{
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+  "agents": {
+    "sisyphus": {
+      "model": "opencode/claude-opus-4-7",
+      "variant": "max",
+      "fallback_models": [
+        {
+          "model": "opencode/kimi-k2.5"
+        },
+        {
+          "model": "openai/gpt-5.5",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/glm-5"
+        },
+        {
+          "model": "opencode/big-pickle"
+        }
+      ]
+    },
+    "hephaestus": {
+      "model": "openai/gpt-5.4-mini",
+      "fallback_models": [
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "medium"
+        }
+      ]
+    },
+    "oracle": {
+      "model": "openai/gpt-5.5",
+      "variant": "high",
+      "fallback_models": [
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "high"
+        },
+        {
+          "model": "opencode/gemini-3.1-pro",
+          "variant": "high"
+        },
+        {
+          "model": "opencode/claude-opus-4-7",
+          "variant": "max"
+        }
+      ]
+    },
+    "librarian": {
+      "model": "openai/gpt-5.4-mini-fast",
+      "fallback_models": [
+        {
+          "model": "opencode/claude-haiku-4-5"
+        },
+        {
+          "model": "openai/gpt-5.4-nano"
+        },
+        {
+          "model": "opencode/gpt-5.4-nano"
+        }
+      ]
+    },
+    "explore": {
+      "model": "openai/gpt-5.4-mini-fast",
+      "fallback_models": [
+        {
+          "model": "opencode/claude-haiku-4-5"
+        },
+        {
+          "model": "openai/gpt-5.4-nano"
+        },
+        {
+          "model": "opencode/gpt-5.4-nano"
+        }
+      ]
+    },
+    "multimodal-looker": {
+      "model": "openai/gpt-5.5",
+      "variant": "medium",
+      "fallback_models": [
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "medium"
+        },
+        {
+          "model": "openai/gpt-5-nano"
+        },
+        {
+          "model": "opencode/gpt-5-nano"
+        }
+      ]
+    },
+    "prometheus": {
+      "model": "opencode/claude-opus-4-7",
+      "variant": "max",
+      "fallback_models": [
+        {
+          "model": "openai/gpt-5.5",
+          "variant": "high"
+        },
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "high"
+        },
+        {
+          "model": "opencode/gemini-3.1-pro"
+        }
+      ]
+    },
+    "metis": {
+      "model": "opencode/claude-opus-4-7",
+      "variant": "max",
+      "fallback_models": [
+        {
+          "model": "openai/gpt-5.5",
+          "variant": "high"
+        },
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "high"
+        }
+      ]
+    },
+    "momus": {
+      "model": "openai/gpt-5.5",
+      "variant": "xhigh",
+      "fallback_models": [
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "xhigh"
+        },
+        {
+          "model": "opencode/claude-opus-4-7",
+          "variant": "max"
+        },
+        {
+          "model": "opencode/gemini-3.1-pro",
+          "variant": "high"
+        }
+      ]
+    },
+    "atlas": {
+      "model": "opencode/claude-sonnet-4-6",
+      "fallback_models": [
+        {
+          "model": "openai/gpt-5.5",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "medium"
+        }
+      ]
+    },
+    "sisyphus-junior": {
+      "model": "opencode/claude-sonnet-4-6",
+      "fallback_models": [
+        {
+          "model": "openai/gpt-5.5",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/big-pickle"
+        }
+      ]
+    }
+  },
+  "categories": {
+    "visual-engineering": {
+      "model": "opencode/gemini-3.1-pro",
+      "variant": "high",
+      "fallback_models": [
+        {
+          "model": "opencode/glm-5"
+        },
+        {
+          "model": "opencode/claude-opus-4-7",
+          "variant": "max"
+        }
+      ]
+    },
+    "ultrabrain": {
+      "model": "openai/gpt-5.5",
+      "variant": "xhigh",
+      "fallback_models": [
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "xhigh"
+        },
+        {
+          "model": "opencode/gemini-3.1-pro",
+          "variant": "high"
+        },
+        {
+          "model": "opencode/claude-opus-4-7",
+          "variant": "max"
+        }
+      ]
+    },
+    "deep": {
+      "model": "openai/gpt-5.4-mini",
+      "fallback_models": [
+        {
+          "model": "opencode/gpt-5.4",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/claude-opus-4-7",
+          "variant": "max"
+        },
+        {
+          "model": "opencode/gemini-3.1-pro",
+          "variant": "high"
+        }
+      ]
+    },
+    "artistry": {
+      "model": "opencode/gemini-3.1-pro",
+      "variant": "high",
+      "fallback_models": [
+        {
+          "model": "opencode/claude-opus-4-7",
+          "variant": "max"
+        },
+        {
+          "model": "openai/gpt-5.5"
+        },
+        {
+          "model": "opencode/gpt-5.4"
+        }
+      ]
+    },
+    "quick": {
+      "model": "openai/gpt-5.4-mini",
+      "fallback_models": [
+        {
+          "model": "opencode/gpt-5.4-mini"
+        },
+        {
+          "model": "opencode/claude-haiku-4-5"
+        },
+        {
+          "model": "opencode/gemini-3-flash"
+        },
+        {
+          "model": "opencode/gpt-5-nano"
+        }
+      ]
+    },
+    "unspecified-low": {
+      "model": "opencode/claude-sonnet-4-6",
+      "fallback_models": [
+        {
+          "model": "openai/gpt-5.3-codex",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/gpt-5.3-codex",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/gemini-3-flash"
+        }
+      ]
+    },
+    "unspecified-high": {
+      "model": "opencode/claude-sonnet-4-6",
+      "fallback_models": [
+        {
+          "model": "openai/gpt-5.3-codex",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/gpt-5.3-codex",
+          "variant": "medium"
+        },
+        {
+          "model": "opencode/gemini-3-flash"
+        }
+      ]
+    },
+    "writing": {
+      "model": "opencode/gemini-3-flash",
+      "fallback_models": [
+        {
+          "model": "opencode/claude-sonnet-4-6"
+        }
+      ]
+    }
+  }
+}

--- a/templates/opencode/opencode.json
+++ b/templates/opencode/opencode.json
@@ -3,7 +3,14 @@
     "oh-my-openagent@latest"
   ],
   "$schema": "https://opencode.ai/config.json",
-  "model": "openai/gpt-5.4",
+  "model": "openai/gpt-5.5",
+  "theme": {
+    "primary": "#6E82D6",
+    "accent": "#8FA2F0",
+    "background": "#081022",
+    "surface": "#0A1338",
+    "text": "#E8EEFF"
+  },
   "provider": {
     "openai": {
       "models": {

--- a/templates/opencode/tui.json
+++ b/templates/opencode/tui.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://opencode.ai/tui.json",
-  "theme": "catppuccin-frappe"
+  "theme": "tokyonight"
 }

--- a/tests/karabiner_module.test.ts
+++ b/tests/karabiner_module.test.ts
@@ -25,7 +25,7 @@ describe('Karabiner module wiring', () => {
   it('exposes bb sync karabiner helper command', () => {
     const functionsSh = readRepoFile('shell/functions.sh');
     expect(functionsSh).toContain('bb sync karabiner');
-    expect(functionsSh).toContain('Usage: bb sync karabiner [push|pull]');
+    expect(functionsSh).toContain('Usage: bb sync <target> [push|pull]');
     expect(functionsSh).toContain('"$dotfiles_dir/scripts/sync-karabiner.sh" "$direction"');
   });
 

--- a/tests/macos_app_backups.test.ts
+++ b/tests/macos_app_backups.test.ts
@@ -7,6 +7,7 @@ describe('macOS app backup organization', () => {
   const setupPath = path.resolve(__dirname, '../setup.ts');
   const functionsPath = path.resolve(__dirname, '../shell/functions.sh');
   const restoreScriptPath = path.resolve(__dirname, '../scripts/restore-macos-app-backups.sh');
+  const syncScriptPath = path.resolve(__dirname, '../scripts/sync-macos-app-backups.sh');
   const docsPath = path.resolve(__dirname, '../docs/modules/app-backups.md');
   const chezmoiDocPath = path.resolve(__dirname, '../docs/modules/chezmoi.md');
 
@@ -18,6 +19,7 @@ describe('macOS app backup organization', () => {
 
   it('documents app backup restore helpers in the README', () => {
     const content = fs.readFileSync(readmePath, 'utf-8');
+    expect(content).toContain('bb sync macos-apps pull');
     expect(content).toContain('bb restore macos-apps');
     expect(content).toContain('assets/app-exports/');
     expect(content).not.toContain('| Mackup | `bb setup mackup`');
@@ -32,17 +34,23 @@ describe('macOS app backup organization', () => {
   it('adds a restore helper command to shell functions', () => {
     const content = fs.readFileSync(functionsPath, 'utf-8');
     expect(content).toContain('bb restore <target>');
+    expect(content).toContain('bb sync macos-apps');
     expect(content).toContain('restore-macos-app-backups.sh');
     expect(content).toContain('raycast, rectangle-pro, bettertouchtool, macos-apps');
   });
 
-  it('adds restore script and docs for app exports', () => {
+  it('adds restore and sync scripts plus docs for app exports', () => {
     const restoreScript = fs.readFileSync(restoreScriptPath, 'utf-8');
+    const syncScript = fs.readFileSync(syncScriptPath, 'utf-8');
     const docs = fs.readFileSync(docsPath, 'utf-8');
     const chezmoiDoc = fs.readFileSync(chezmoiDocPath, 'utf-8');
 
     expect(restoreScript).toContain('Revealing macOS app backup exports');
     expect(restoreScript).toContain('Raycast-2026-04-22-23-03-14.rayconfig');
+    expect(syncScript).toContain('Usage: ./scripts/sync-macos-app-backups.sh [pull|push] [target]');
+    expect(syncScript).toContain('Copy live machine exports -> dotfiles');
+    expect(syncScript).toContain('Import in Raycast using Preferences -> Advanced -> Import Backup.');
+    expect(docs).toContain('bb sync macos-apps pull');
     expect(docs).toContain('Default.bttpreset');
     expect(chezmoiDoc).toContain('real chezmoi-first bootstrap lane');
   });


### PR DESCRIPTION
## Summary

- **macOS app export sync**: new `scripts/sync-macos-app-backups.sh` + `bb sync macos-apps [pull|push]` command to pull Raycast/Rectangle Pro/BetterTouchTool live exports into the repo and reveal/import them back. Individual targets (`raycast`, `rectangle-pro`, `bettertouchtool`) also supported.
- **OpenCode overhaul**: bump default model to `gpt-5.5`, apply a cool-blue theme palette in `opencode.json`, switch TUI theme to `tokyonight`, add `oh-my-openagent.json` with full named-agent + category config, wire it into `bb setup opencode`, and add `docs/modules/opencode.md`.
- **Neru hotkeys**: disable 4 conflicting default shortcuts (`Primary+Shift+Space/G/C/S`).
- **Tooling**: update Claude symlink to v2.1.119 (macOS path), add `comment-checker` binary, update `b2v` binary.
- **Tests + docs**: update README, `app-backups.md`, `chezmoi.md`, and tests to match new sync command signatures.

## Test plan

- [ ] `bb sync macos-apps pull` copies fresh exports into `assets/app-exports/`
- [ ] `bb sync raycast pull` / `bb sync rectangle-pro pull` / `bb sync bettertouchtool pull` work individually
- [ ] `bb sync macos-apps push` reveals files and prints import instructions
- [ ] `bb setup opencode` copies all three templates (`opencode.json`, `oh-my-openagent.json`, `tui.json`) to `~/.config/opencode/`
- [ ] OpenCode launches with tokyonight theme and blue palette
- [ ] Tests pass: `bun test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)